### PR TITLE
Add Monster state system (Awake/Asleep/Dead states)

### DIFF
--- a/src/main/Compact.java
+++ b/src/main/Compact.java
@@ -67,7 +67,7 @@ class Compact extends JFrame{
 	   return button;
 	}
   private void changeControl(JButton b ,int current, String title, Consumer<Integer> update) {
-	  b.setText("Press a key to replace "+ KeyEvent.getKeyText(current));
+	  b.setText("Press a key to replace "+ KeyEvent.getKeyText(current)); //TODO fix bug
 	  KeyAdapter keyListener = new KeyAdapter() {
 	        @Override
 			public void keyPressed(KeyEvent e) {

--- a/src/main/Keys.java
+++ b/src/main/Keys.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.swing.SwingUtilities;
-
+//TODO check if matches first task
 class Keys implements KeyListener {
   private final Map<Integer,Runnable> actionsPressed= new HashMap<>();
   private final Map<Integer,Runnable> actionsReleased= new HashMap<>();

--- a/src/main/Monster.java
+++ b/src/main/Monster.java
@@ -5,22 +5,22 @@ import java.awt.Graphics;
 import imgs.Img;
 
 class Monster implements Entity{
+  EntityState state = new AwakeMonster();
   private Point location;
   @Override
   public Point location(){ return location; }
   @Override
   public void location(Point p){ location = p; }
   Monster(Point location){ this.location= location; }
-  public double speed(){ return 0.05d; }
+  public double speed() {return state.speed();}
   @Override
   public void ping(Model m){
     var arrow= m.camera().location().distance(location); 
     double size= arrow.size();
     arrow = arrow.times(speed() / size);
-    location = location.add(arrow); 
-    if (size < 0.6d){ m.onGameOver(); }
-  }
- 
+    location = location.add(arrow);
+    state.ping(size,m,this);
+  } 
   public double chaseTarget(Monster outer, Point target){
     var arrow= target.distance(outer.location());
     double size= arrow.size();
@@ -28,8 +28,59 @@ class Monster implements Entity{
     outer.location(outer.location().add(arrow));
     return size;
   }
+  public void hit(){state = new DeadMonster();} 
   @Override
   public void draw(Graphics g, Point center, Dimension size) {
-    drawImg(Img.AwakeMonster.image, g, center, size);
+    state.draw(this, g, center, size);
   }
 }
+
+interface EntityState{
+	void draw(Monster Self, Graphics g, Point center, Dimension size);
+	double speed();
+	void ping(double size ,Model m, Monster self);
+	}
+
+class AwakeMonster implements EntityState{
+	@Override
+	public void draw(Monster self, Graphics g, Point center, Dimension size) {
+	self.drawImg(Img.AwakeMonster.image, g, center, size);
+	}
+	@Override
+	public double speed(){ return 0.05d; }
+    @Override
+	public void ping(double size, Model m, Monster self){
+	    if(size > 6) {self.state = new AsleepMonster();}
+	    if (size < 0.6d){ m.onGameOver(); }
+	  }
+}
+class AsleepMonster implements EntityState{
+	@Override
+	public void draw(Monster self, Graphics g, Point center, Dimension size) {
+	self.drawImg(Img.SleepMonster.image, g, center, size);
+	}
+	@Override
+	public double speed(){ return 0.0d; }
+	@Override
+	public void ping(double size, Model m, Monster self){
+	    if(size < 6) {self.state = new AwakeMonster();}
+	  }
+}
+class DeadMonster implements EntityState{
+	private int count = 0;
+	@Override
+	public void draw(Monster self, Graphics g, Point center, Dimension size) {
+	self.drawImg(Img.DeadMonster.image, g, center, size);
+	}
+	@Override
+	public double speed(){ return 0.0d; }
+	@Override
+	public void ping(double size, Model m, Monster self){
+    count++;
+    if(count>=100) {m.remove(self);}
+	  }
+}
+
+
+
+	

--- a/src/main/Sword.java
+++ b/src/main/Sword.java
@@ -16,8 +16,8 @@ public Point location(){
     return dir.times(distance()).add(wielder.location());
   }
   public void onHit(Model m, Entity e){ 
-    if (e instanceof Monster){ m.remove(e); }
-  }
+    if (e instanceof Monster){((Monster)e).hit();} //changed here
+  } 
 
   public double effectRange(){ return 0.3d; } 
   


### PR DESCRIPTION
Implemented the State pattern for Monster entities to handle different behavioral states (Awake, Asleep, Dead) with proper state transitions and unique behaviors.

- Refactored Monster class to use State pattern instead of hardcoded behavior
- Created EntityState interface for monster states (draw, speed, ping methods)
- Implemented three monster states:
 - AwakeMonster: Chases player, sleeps when far away
 - AsleepMonster: Stationary, wakes when player is close
 - DeadMonster: Shows death sprite, removes after 100 ticks
- Enhanced sword to properly kill monsters
- Fixed game logic so only living monsters can kill the player